### PR TITLE
#13 アプリ全体のスタイルをthemeで統一

### DIFF
--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -1,2 +1,6 @@
 # https://pub.dev/packages/pedantic_mono
 include: package:pedantic_mono/analysis_options.yaml
+
+linter:
+  rules:
+    avoid_classes_with_only_static_members: false # 名前空間に使用

--- a/lib/component/app_color.dart
+++ b/lib/component/app_color.dart
@@ -1,0 +1,9 @@
+import 'package:flutter/material.dart';
+
+class AppColor {
+  static Color text = const Color(0xFF24292E);
+  static Color accent = const Color(0xFF2C974B);
+  static Color main = const Color(0xFFFFFFFF);
+  static Color back = const Color(0xFFF5F8FA);
+  static Color cursor = Colors.blue;
+}

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:github_search/component/app_color.dart';
 import 'package:github_search/view/home_page.dart';
 
 void main() {
@@ -19,19 +20,58 @@ class MyApp extends StatelessWidget {
       title: 'Flutter Demo',
       theme: ThemeData(
         colorScheme: ColorScheme.fromSwatch().copyWith(
-          primary: const Color(0xFFFFFFFF),
-          secondary: const Color(0xFF2C974B),
-          onPrimary: const Color(0xFF24292E),
+          primary: AppColor.main,
+          secondary: AppColor.accent,
+          onPrimary: AppColor.text,
         ),
         scaffoldBackgroundColor: const Color(0xFFF5F8FA),
+        textTheme: TextTheme(
+          headline6: const TextStyle(
+            fontWeight: FontWeight.bold,
+          ),
+          subtitle1: TextStyle(
+            color: AppColor.text,
+            fontSize: 28,
+            fontWeight: FontWeight.bold,
+          ),
+          bodyText1: TextStyle(
+            color: AppColor.text,
+            fontSize: 16,
+          ),
+          bodyText2: TextStyle(
+            color: AppColor.text,
+            // textBaseline: TextBaseline.values,
+          ),
+        ),
       ),
       darkTheme: ThemeData.dark().copyWith(
-        colorScheme: ColorScheme.fromSwatch().copyWith(
-          primary: const Color(0xFF24292E),
-          secondary: const Color(0xFF2C974B),
-          onPrimary: const Color(0xFFFFFFFF),
+        iconTheme: IconThemeData(
+          color: AppColor.text,
         ),
-        scaffoldBackgroundColor: const Color(0xFFF5F8FA),
+        colorScheme: ColorScheme.fromSwatch().copyWith(
+          primary: AppColor.text,
+          secondary: AppColor.accent,
+          onPrimary: AppColor.main,
+        ),
+        textTheme: TextTheme(
+          headline6: const TextStyle(
+            fontWeight: FontWeight.bold,
+          ),
+          subtitle1: TextStyle(
+            color: AppColor.text,
+            fontSize: 28,
+            fontWeight: FontWeight.bold,
+          ),
+          bodyText1: TextStyle(
+            color: AppColor.main,
+            fontSize: 16,
+          ),
+          bodyText2: TextStyle(
+            color: AppColor.text,
+            // textBaseline: TextBaseline.values,
+          ),
+        ),
+        scaffoldBackgroundColor: AppColor.back,
       ),
       home: const HomePage(),
     );

--- a/lib/view/home_page.dart
+++ b/lib/view/home_page.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_hooks/flutter_hooks.dart';
+import 'package:github_search/component/app_color.dart';
 import 'package:github_search/model/github_repository.dart';
 import 'package:github_search/service/github_client.dart';
 import 'package:github_search/view/repository_detail_page.dart';
@@ -21,6 +22,7 @@ class HomePage extends HookConsumerWidget {
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
+    final textTheme = Theme.of(context).textTheme;
     final focusNode = useFocusNode();
     final scrollController = useScrollController();
     final elevation = ref.watch(_elevationProvider.state);
@@ -44,11 +46,9 @@ class HomePage extends HookConsumerWidget {
       appBar: AppBar(
         centerTitle: true,
         elevation: elevation.state,
-        title: const Text(
+        title: Text(
           'ホーム',
-          style: TextStyle(
-            fontWeight: FontWeight.bold,
-          ),
+          style: textTheme.headline6,
         ),
       ),
       body: SafeArea(
@@ -82,24 +82,30 @@ class HomePage extends HookConsumerWidget {
                           'images/github_icon.png',
                           height: 100,
                         ),
-                        const Text('loading...'),
+                        Text('loading...', style: textTheme.bodyText2),
                       ],
                     ),
                   ),
                 ),
                 error: (error, stack) {
                   print(error);
-                  return const SliverToBoxAdapter(
+                  return SliverToBoxAdapter(
                     child: Center(
-                      child: Text('データを取得できませんでした。'),
+                      child: Text(
+                        'データを取得できませんでした。',
+                        style: textTheme.bodyText2,
+                      ),
                     ),
                   );
                 },
                 data: (repositories) {
                   if (repositories.isEmpty) {
-                    return const SliverFillRemaining(
+                    return SliverFillRemaining(
                       child: Center(
-                        child: Text('該当のリポジトリはありませんでした。'),
+                        child: Text(
+                          '該当のリポジトリはありませんでした。',
+                          style: textTheme.bodyText2,
+                        ),
                       ),
                     );
                   } else {
@@ -133,7 +139,10 @@ class HomePage extends HookConsumerWidget {
                                 );
                               },
                               child: ListTile(
-                                title: Text(repositories[index].name!),
+                                title: Text(
+                                  repositories[index].name!,
+                                  style: textTheme.bodyText1,
+                                ),
                               ),
                             ),
                           );
@@ -153,6 +162,7 @@ class HomePage extends HookConsumerWidget {
 
   Widget _buildTextField(
       BuildContext context, WidgetRef ref, FocusNode focusNode) {
+    final textTheme = Theme.of(context).textTheme;
     final text = ref.watch(_searchTextProvider.state);
 
     Future<void> search(String query) async {
@@ -162,10 +172,11 @@ class HomePage extends HookConsumerWidget {
     final textController = useTextEditingController();
 
     return TextField(
+      style: textTheme.bodyText2,
       controller: textController,
       focusNode: focusNode,
       onSubmitted: search,
-      cursorColor: Colors.blue,
+      cursorColor: AppColor.cursor,
       textAlignVertical: TextAlignVertical.center,
       decoration: InputDecoration(
         enabledBorder: const OutlineInputBorder(
@@ -200,6 +211,7 @@ class HomePage extends HookConsumerWidget {
           ),
         ),
         hintText: 'リポジトリを検索',
+        hintStyle: textTheme.bodyText2,
         isCollapsed: true,
       ),
     );

--- a/lib/view/repository_detail_page.dart
+++ b/lib/view/repository_detail_page.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:github_search/component/app_color.dart';
 
 class RepositoryDetailPage extends StatelessWidget {
   const RepositoryDetailPage(
@@ -24,6 +25,8 @@ class RepositoryDetailPage extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    final textTheme = Theme.of(context).textTheme;
+
     return Scaffold(
       appBar: AppBar(
         centerTitle: true,
@@ -53,19 +56,22 @@ class RepositoryDetailPage extends StatelessWidget {
                     const SizedBox(height: 20),
                     Text(
                       name ?? '',
-                      style: const TextStyle(
-                        fontWeight: FontWeight.bold,
-                        fontSize: 28,
-                      ),
+                      style: textTheme.subtitle1,
                     ),
                     const SizedBox(height: 20),
                     Row(
                       children: [
                         const Icon(Icons.star_outline),
-                        Text('$starCount Star'),
+                        Text(
+                          '$starCount Star',
+                          style: textTheme.bodyText2,
+                        ),
                         const SizedBox(width: 20),
                         const Icon(Icons.call_split),
-                        Text('$folkCount Folk'),
+                        Text(
+                          '$folkCount Folk',
+                          style: textTheme.bodyText2,
+                        ),
                       ],
                     ),
                     const SizedBox(height: 20),
@@ -126,6 +132,8 @@ class ListItem extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    final textTheme = Theme.of(context).textTheme;
+
     return Padding(
       padding: const EdgeInsets.only(bottom: 20),
       child: Row(
@@ -148,13 +156,17 @@ class ListItem extends StatelessWidget {
               const SizedBox(width: 10),
               Text(
                 title,
-                style: const TextStyle(fontSize: 18),
+                style: textTheme.bodyText1?.copyWith(
+                  color: AppColor.text,
+                ),
               ),
             ],
           ),
           Text(
             trailing,
-            style: const TextStyle(fontSize: 18),
+            style: textTheme.bodyText1?.copyWith(
+              color: AppColor.text,
+            ),
           ),
         ],
       ),


### PR DESCRIPTION
#13 対応

### やったこと
- アプリ全体の色をapp_color.dartで管理
- 一部のlinterルールを無効
- Themeでアプリ全体のスタイルを管理
- ホームページのスタイルをThemeで統一
- リポジトリ詳細ページのスタイルをThemeで統一